### PR TITLE
Fix KeyError

### DIFF
--- a/src/deploy/aws/ecs.py
+++ b/src/deploy/aws/ecs.py
@@ -242,8 +242,6 @@ class ECSServiceClient:
         # Copy, then remove keys that may not be re-submitted.
         currentTaskDefinition = dict(currentTaskDefinition)
         del currentTaskDefinition["revision"]
-        del currentTaskDefinition["registeredAt"]
-        del currentTaskDefinition["registeredBy"]
         del currentTaskDefinition["status"]
         del currentTaskDefinition["taskDefinitionArn"]
         if "FARGATE" in currentTaskDefinition["compatibilities"]:

--- a/src/deploy/aws/test/test_ecs.py
+++ b/src/deploy/aws/test/test_ecs.py
@@ -138,8 +138,6 @@ class MockBoto3ECSClient:
             "taskDefinitionArn": f"{_defaultARNNamespace}:0",
             "family": "service-fg",
             "revision": 1,
-            "registeredAt": 1234,
-            "registeredBy": "?",
             "containerDefinitions": [
                 {
                     "name": "service-container",
@@ -180,8 +178,6 @@ class MockBoto3ECSClient:
             "taskDefinitionArn": f"{_defaultARNNamespace}:1",
             "family": "service-fg",
             "revision": 1,
-            "registeredAt": 1234,
-            "registeredBy": "?",
             "containerDefinitions": [
                 {
                     "name": "service-container",


### PR DESCRIPTION
`registeredAt` and `registeredBy` are no longer thrown into the retrieved current task definition