### PR TITLE
Fix KeyError with a conditional delete

### DIFF
--- a/src/deploy/aws/ecs.py
+++ b/src/deploy/aws/ecs.py
@@ -242,6 +242,8 @@ class ECSServiceClient:
         # Copy, then remove keys that may not be re-submitted.
         currentTaskDefinition = dict(currentTaskDefinition)
         del currentTaskDefinition["revision"]
+        del currentTaskDefinition["registeredAt"]
+        del currentTaskDefinition["registeredBy"]
         del currentTaskDefinition["status"]
         del currentTaskDefinition["taskDefinitionArn"]
         if "FARGATE" in currentTaskDefinition["compatibilities"]:

--- a/src/deploy/aws/ecs.py
+++ b/src/deploy/aws/ecs.py
@@ -241,14 +241,22 @@ class ECSServiceClient:
 
         # Copy, then remove keys that may not be re-submitted.
         currentTaskDefinition = dict(currentTaskDefinition)
-        del currentTaskDefinition["revision"]
-        del currentTaskDefinition["registeredAt"]
-        del currentTaskDefinition["registeredBy"]
-        del currentTaskDefinition["status"]
-        del currentTaskDefinition["taskDefinitionArn"]
+        extraFields: Tuple[str, ...] = (
+            "revision",
+            "registeredAt",
+            "registeredBy",
+            "status",
+            "taskDefinitionArn",
+        )
         if "FARGATE" in currentTaskDefinition["compatibilities"]:
-            del currentTaskDefinition["compatibilities"]
-            del currentTaskDefinition["requiresAttributes"]
+            extraFields += (
+                "compatibilities",
+                "requiresAttributes",
+            )
+
+        for field in extraFields:
+            if field in currentTaskDefinition:
+                del currentTaskDefinition[field]
 
         # Deep copy the current task definition for editing.
         newTaskDefinition = deepcopy(currentTaskDefinition)

--- a/src/deploy/aws/test/test_ecs.py
+++ b/src/deploy/aws/test/test_ecs.py
@@ -138,6 +138,8 @@ class MockBoto3ECSClient:
             "taskDefinitionArn": f"{_defaultARNNamespace}:0",
             "family": "service-fg",
             "revision": 1,
+            "registeredAt": 1234,
+            "registeredBy": "?",
             "containerDefinitions": [
                 {
                     "name": "service-container",
@@ -178,6 +180,8 @@ class MockBoto3ECSClient:
             "taskDefinitionArn": f"{_defaultARNNamespace}:1",
             "family": "service-fg",
             "revision": 1,
+            "registeredAt": 1234,
+            "registeredBy": "?",
             "containerDefinitions": [
                 {
                     "name": "service-container",


### PR DESCRIPTION
It seems that `registeredAt` and `registeredBy` are still around sometimes, so just change the code to handle both cases.