### PR TITLE
"The push refers to a repository" ➜ "The push refers to repository"

### DIFF
--- a/src/deploy/aws/ecr.py
+++ b/src/deploy/aws/ecr.py
@@ -306,7 +306,7 @@ class ImagePushResult:
 class DockerPushResponseHandler:
     log = Logger()
 
-    _repoStatusPrefix = "The push refers to a repository ["
+    _repoStatusPrefix = "The push refers to repository ["
     _repoStatusSuffix = "]"
 
     repository: str

--- a/src/deploy/aws/test/test_ecr.py
+++ b/src/deploy/aws/test/test_ecr.py
@@ -190,7 +190,7 @@ class MockImagesAPI:
 
         # Fake some activity
         json = [
-            {"status": f"The push refers to a repository [{repository}]"},
+            {"status": f"The push refers to repository [{repository}]"},
             {"status": "Preparing", "id": image.id, "progressDetail": {}},
             {"status": "Waiting", "id": image.id, "progressDetail": {}},
             {
@@ -510,8 +510,7 @@ class ECRServiceClientTests(TestCase):
 
             handler: DockerPushResponseHandler = failureEvent["log_source"]
 
-            self.assertEqual(len(handler.errors), 1)
-            self.assertEqual(handler.errors[0], fakeNewsError)
+            self.assertEqual(handler.errors, [fakeNewsError])
 
         self.flushLoggedErrors()
 
@@ -564,7 +563,7 @@ class DockerPushResponseHandlerTests(TestCase):
     def test_handleGeneralStatusUpdate_init(self, repository: str) -> None:
         handler = DockerPushResponseHandler(repository=repository, tag="tag")
         handler._handleGeneralStatusUpdate(
-            json={"status": f"The push refers to a repository [{repository}]"}
+            json={"status": f"The push refers to repository [{repository}]"}
         )
         self.assertEqual(handler.errors, [])
 

--- a/src/deploy/aws/test/test_ecr.py
+++ b/src/deploy/aws/test/test_ecr.py
@@ -190,7 +190,13 @@ class MockImagesAPI:
 
         # Fake some activity
         json = [
-            {"status": f"The push refers to repository [{repository}]"},
+            {
+                "status": (
+                    f"{DockerPushResponseHandler._repoStatusPrefix}"
+                    f"{repository}"
+                    f"{DockerPushResponseHandler._repoStatusSuffix}"
+                )
+            },
             {"status": "Preparing", "id": image.id, "progressDetail": {}},
             {"status": "Waiting", "id": image.id, "progressDetail": {}},
             {
@@ -563,7 +569,13 @@ class DockerPushResponseHandlerTests(TestCase):
     def test_handleGeneralStatusUpdate_init(self, repository: str) -> None:
         handler = DockerPushResponseHandler(repository=repository, tag="tag")
         handler._handleGeneralStatusUpdate(
-            json={"status": f"The push refers to repository [{repository}]"}
+            json={
+                "status": (
+                    f"{DockerPushResponseHandler._repoStatusPrefix}"
+                    f"{repository}"
+                    f"{DockerPushResponseHandler._repoStatusSuffix}"
+                )
+            }
         )
         self.assertEqual(handler.errors, [])
 


### PR DESCRIPTION
Fixes #49 